### PR TITLE
feat: add TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+/**
+ * TypeScript type definitions for chrome-extension-manifest-json-schema
+ */
+
+export interface ChromeExtensionManifestSchema {
+  /**
+   * JSON Schema object for Chrome extension manifest V2
+   */
+  manifestV2Schema: object;
+  
+  /**
+   * JSON Schema object for Chrome extension manifest V3
+   */
+  manifestV3Schema: object;
+}
+
+declare const schemas: ChromeExtensionManifestSchema;
+
+export default schemas;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "license": "MIT",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/cezaraugusto/chrome-extension-manifest-json-schema.git"


### PR DESCRIPTION
This PR adds TypeScript type definitions to chrome-extension-manifest-json-schema.

## Changes
- Added `index.d.ts` with type definitions
- Added the `types` field to package.json

## Type Definitions
- `ChromeExtensionManifestSchema` - Interface for the exported schema object
- Exports `manifestV2Schema` and `manifestV3Schema` as JSON schema objects

This enables TypeScript users to get proper type hints when using this Chrome extension manifest JSON schema package.